### PR TITLE
#161945591 Fix redux devtools extension bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-test-renderer": "^16.6.1",
     "react-social-login": "^3.4.2",
     "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.5",
     "redux-immutable-state-invariant": "^2.1.0",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.3",
@@ -67,7 +68,6 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
-    "redux-devtools-extension": "^2.13.5",
     "redux-logger": "^3.0.6"
   },
   "jest": {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,7 +2,7 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import reduxImmutableStateInvariant from 'redux-immutable-state-invariant';
 import { logger } from 'redux-logger';
-import { composeWithDevTools } from 'redux-devtools-extension';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import rootReducer from './rootReducer';
 
 export default function configureStore(initialState) {


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the `redux devtools` extension bug on Heroku.

**Description of Task to be completed?**

##### Steps to reproduce
Visit https://ah-cd-frontend-staging.herokuapp.com/, the staging app or any review app on Heroku.

##### Expected
The app should load without crashing.

##### Actual
The app fails to compile with the error `./src/store/index.js
Module not found: Can't resolve 'redux-devtools-extension' in '/app/src/store'`.

**How should this be manually tested?**

This can be tested by visiting this PR's heroku [review app](https://ah-cd-frontend-staging-pr-23.herokuapp.com/).

**Any background context you want to provide?**

From the Redux DevTools Extension's helper usage [description](https://www.npmjs.com/package/redux-devtools-extension#usage), it should not be installed as a production dependency.

**What are the relevant pivotal tracker stories?**

[#161945591](https://www.pivotaltracker.com/story/show/161945591)

**Screenshots**
Before
<img width="1127" alt="screen shot 2018-11-14 at 07 10 39" src="https://user-images.githubusercontent.com/8180548/48461617-9057cb80-e7e5-11e8-9e74-5c008ff48dc0.png">

After
<img width="869" alt="screen shot 2018-11-14 at 08 15 19" src="https://user-images.githubusercontent.com/8180548/48461613-8cc44480-e7e5-11e8-80b8-99e2d5dd2570.png">
