### PR TITLE
#162148913 Allow review apps to inherit REACT_APP_API_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,11 @@
 {
   "name": "ah-codeblooded-frontend",
   "scripts": {},
-  "env": {},
+  "env": {
+    "REACT_APP_API_URL": {
+      "required": true
+    }
+  },
   "formation": {
     "web": {
       "quantity": 1


### PR DESCRIPTION
**What does this PR do?**

Enables review apps to inherit config vars from the staging application.

**Description of Task to be completed?**

##### Steps to reproduce
Open a review app for a newly created PR i.e. one where env variables have not been set explicitly.

##### Expected
The review should work without having to manually set env variables.

##### Actual
The review app fails to work.

**How should this be manually tested?**

Open this PR's [review app](https://ah-cd-frontend-staging-pr-36.herokuapp.com/). It should work despite the fact that the `REACT_APP_API_URL` has not been set manually.

**Any background context you want to provide?**

From Heroku Documentation on review apps, it is possible to inherit config vars from the parent application. See https://devcenter.heroku.com/articles/github-integration-review-apps#inheriting-config-vars.

The social auth variables cannot be inherited because they are specific to the app domain. This is because review apps have different domain names. If you need them you will have to set them manually.

**What are the relevant pivotal tracker stories?**

[#162148913](https://www.pivotaltracker.com/story/show/162148913)

**Screenshots (if appropriate)**
This will automatically the REACT_APP_API_URL config var as it appears on the staging app.
<img width="810" alt="screen shot 2018-11-22 at 10 19 51" src="https://user-images.githubusercontent.com/8180548/48887400-363bb380-ee40-11e8-8eda-d2be73b8c899.png">
