### PR TITLE
#160577586 Enable users to filter articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ yarn-error.log*
 
 .eslintrc.js
 
+/.history

--- a/src/components/DropDown/index.js
+++ b/src/components/DropDown/index.js
@@ -6,8 +6,8 @@ import './DropDown.scss';
 class DropDown extends React.Component {
   componentDidMount = () => {
     const dropdown = document.querySelectorAll('.dropdown-trigger');
-    const { options, closeTrigger } = this.props;
-    this.instance = Materialize.Dropdown.init(dropdown, {
+    const { options, closeTrigger, id } = this.props;
+    Materialize.Dropdown.init(dropdown, {
       alignment: 'center',
       constrainWidth: false,
       coverTrigger: false,
@@ -18,7 +18,8 @@ class DropDown extends React.Component {
       /* istanbul ignore next */
       document.querySelectorAll(closeTrigger).forEach((item) => {
         item.addEventListener('click', () => {
-          this.instance.close();
+          const instance = Materialize.Dropdown.getInstance(document.querySelector(`#${id}-trigger`));
+          instance.close();
         });
       });
     }
@@ -27,7 +28,7 @@ class DropDown extends React.Component {
   render = () => {
     const { id, list, children } = this.props;
     return (
-      <div id={id} className="dropdown-content drop-down">
+      <div id={id} className="dropdown-content drop-down" ref={(dropdown) => { this.dropdown = dropdown; }}>
         {list ? (
           <ul>
             {list}

--- a/src/containers/FilterDropDown/FilterDropDown.scss
+++ b/src/containers/FilterDropDown/FilterDropDown.scss
@@ -1,0 +1,13 @@
+// scss-lint:disable IdSelector
+#filter-dropdown {
+  min-width: 300px;
+  padding: .5em;
+
+  .content {
+    padding: .5em;
+  }
+
+  .footer {
+    padding: 1em;
+  }
+}

--- a/src/containers/FilterDropDown/FilterDropDown.test.js
+++ b/src/containers/FilterDropDown/FilterDropDown.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import FilterDropDown from '.';
+
+const author = {
+  username: 'bevkololi',
+  bio: 'This is a bio',
+  image: 'image',
+};
+
+const tag = {
+  tag: 'andela',
+};
+
+const props = {
+  author,
+  tag,
+  filtersChanged: jest.fn(),
+  onFilter: jest.fn(),
+  clearFilters: jest.fn(),
+  selectAll: jest.fn(),
+};
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+const store = mockStore({
+  filterArticles: {
+    authors: { ...author },
+    tags: { ...tag },
+  },
+});
+
+const wrapper = mount(<FilterDropDown {...props} store={store} />, { attachTo: document.body });
+
+describe('View Profile container', () => {
+  it('should render without crashing', () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('should ensure users can update their profile image', () => {
+    wrapper.find('button').at(1).simulate('click');
+    expect(props.onFilter.mock.calls.length).toEqual(0);
+  });
+
+  it('should ensure users can update their profile image', () => {
+    wrapper.find('button').at(0).simulate('click');
+    expect(props.clearFilters.mock.calls.length).toEqual(0);
+  });
+
+  it('should select the whole field on focus', () => {
+    wrapper.find('input').at(1).simulate('focus');
+    expect(props.selectAll.mock.calls.length).toEqual(0);
+  });
+
+  it('should receive a list of authors and tags', () => {
+    wrapper.setProps({ authors: [author], tags: [tag] });
+    expect(wrapper.instance().authorsInstance).toBeUndefined();
+  });
+});

--- a/src/containers/FilterDropDown/index.js
+++ b/src/containers/FilterDropDown/index.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import './FilterDropDown.scss';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+import Materialize from 'materialize-css';
+import { connect } from 'react-redux';
+import DropDown from '../../components/DropDown';
+import { fetchAuthorsAction, fetchTagsAction } from './state/actions';
+
+class FilterDropDown extends React.Component {
+  componentDidMount = () => {
+    const { fetchTags, fetchAuthors } = this.props;
+    fetchTags();
+    fetchAuthors();
+  }
+
+  selectAll = (e) => {
+    e.target.select();
+  };
+
+  componentWillReceiveProps = (nextProps) => {
+    this.authorsInstance = Materialize.Autocomplete.init(this.authors, { data: nextProps.authors });
+    this.tagsInstance = Materialize.Autocomplete.init(this.tags, { data: nextProps.tags });
+  };
+
+  onFilter = () => {
+    const { authors, filtersChanged } = this.props;
+    const tag = this.tags.value;
+    const author = this.authors.value
+      ? { username: this.authors.value, image: authors[this.authors.value] } : null;
+
+    filtersChanged(tag, author);
+  };
+
+  clearFilters = () => {
+    this.authors.value = '';
+    this.tags.value = '';
+    Materialize.updateTextFields();
+  }
+
+  render() {
+    return (
+      <DropDown
+        id="filter-dropdown"
+        options={{ closeOnClick: false, constrainWidth: false }}
+        closeTrigger=".dropdown-close"
+      >
+        <div className="title">
+          <h5>Filter by</h5>
+        </div>
+        <div className="content">
+          <div className="input-field">
+            <input
+              type="text"
+              name="author"
+              onFocus={this.selectAll}
+              className="autocomplete"
+              id="authors"
+              ref={(authors) => { this.authors = authors; }}
+            />
+            <label>Author</label>
+          </div>
+          <div className="input-field">
+            <input
+              type="text"
+              name="tag"
+              onFocus={this.selectAll}
+              className="autocomplete"
+              id="tags"
+              ref={(tags) => { this.tags = tags; }}
+            />
+            <label>Tag</label>
+          </div>
+        </div>
+        <div className="footer">
+          <div className="row right">
+            <button className="btn btn-flat white" type="button" onClick={this.clearFilters}>Clear</button>
+            <button className="btn dropdown-close" type="button" onClick={this.onFilter}>Apply</button>
+          </div>
+        </div>
+      </DropDown>
+    );
+  }
+}
+
+FilterDropDown.propTypes = {
+  fetchTags: PropTypes.func.isRequired,
+  fetchAuthors: PropTypes.func.isRequired,
+  authors: PropTypes.shape({}).isRequired,
+  tags: PropTypes.shape({}).isRequired,
+  filtersChanged: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ filterArticles }) => filterArticles;
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  fetchAuthors: fetchAuthorsAction,
+  fetchTags: fetchTagsAction,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(FilterDropDown);

--- a/src/containers/FilterDropDown/state/actions.js
+++ b/src/containers/FilterDropDown/state/actions.js
@@ -1,0 +1,12 @@
+import api from '../../../utils/api';
+import { FETCH_AUTHORS, FETCH_TAGS } from './types';
+
+export const fetchAuthorsAction = () => dispatch => api.get('users/search/')
+  .then((response) => {
+    dispatch({ type: FETCH_AUTHORS, payload: response.data });
+  });
+
+export const fetchTagsAction = () => dispatch => api.get('tags/')
+  .then((response) => {
+    dispatch({ type: FETCH_TAGS, payload: response.data });
+  });

--- a/src/containers/FilterDropDown/state/actions.test.js
+++ b/src/containers/FilterDropDown/state/actions.test.js
@@ -1,0 +1,33 @@
+import * as actions from './actions';
+import { mockStore, axiosMock } from '../../../utils/testHelpers';
+import { getURL } from '../../../utils/api';
+
+const payload = {
+  author: {
+    username: 'testuser',
+    bio: 'This is a bio',
+    image:
+      'https://t3.ftcdn.net/jpg/01/83/55/76/500_F_183557656_DRcvOesmfDl5BIyhPKrcWANFKy2964i9.jpg',
+  },
+  tags: {
+    tag: 'tag',
+  },
+};
+
+const store = mockStore({});
+
+describe('Filter dropdown actions', () => {
+  it('should get the authors of articles', () => {
+    axiosMock.onGet(getURL('users/search/')).reply(200, payload);
+    store.dispatch(actions.fetchAuthorsAction('testuser')).then(() => {
+      expect(store.getActions()).toContainEqual({ type: actions.FETCH_AUTHORS, payload });
+    });
+  });
+
+  it('should get tags of articles', () => {
+    axiosMock.onGet(getURL('tags/')).reply(200, payload);
+    store.dispatch(actions.fetchTagsAction('tag')).then(() => {
+      expect(store.getActions()).toContainEqual({ type: actions.FETCH_TAGS, payload });
+    });
+  });
+});

--- a/src/containers/FilterDropDown/state/reducer.js
+++ b/src/containers/FilterDropDown/state/reducer.js
@@ -1,0 +1,30 @@
+import { FETCH_AUTHORS, FETCH_TAGS } from './types';
+
+export const initialState = {
+  tags: {},
+  authors: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+  case FETCH_AUTHORS: {
+    const { payload: { data } } = action;
+    const authors = {};
+    data.forEach((author) => {
+      authors[author.username] = author.image;
+    });
+
+    return { ...state, authors };
+  }
+  case FETCH_TAGS: {
+    const { payload: { data: { tags } } } = action;
+    const tagSlugs = {};
+    tags.forEach((tag) => {
+      tagSlugs[tag.slug] = null;
+    });
+    return { ...state, tags: tagSlugs };
+  }
+  default:
+    return state;
+  }
+};

--- a/src/containers/FilterDropDown/state/reducer.test.js
+++ b/src/containers/FilterDropDown/state/reducer.test.js
@@ -1,0 +1,61 @@
+import articleFilterReducer, { initialState } from './reducer';
+import { FETCH_AUTHORS, FETCH_TAGS } from './types';
+
+const filterAuthors = {
+  type: FETCH_AUTHORS,
+  payload: {
+    data: [{
+      username: 'bevkololi',
+      bio: 'My bio',
+      image: 'My image',
+    }],
+  },
+};
+
+const filterTags = {
+  type: FETCH_TAGS,
+  payload: {
+    data: {
+      tags: [{
+        tag: 'tag',
+      }],
+    },
+  },
+};
+
+let authors;
+let tagSlugs;
+
+describe('The filter articles reducer', () => {
+  beforeEach(() => {
+    const { payload: { data } } = filterAuthors;
+    authors = {};
+    data.forEach((author) => {
+      authors[author.username] = author.image;
+    });
+
+    const { payload: { data: { tags } } } = filterTags;
+    tagSlugs = {};
+    tags.forEach((tag) => {
+      tagSlugs[tag.slug] = null;
+    });
+  });
+
+  it('should return the initial state', () => {
+    expect(articleFilterReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle FETCH_AUTHORS', () => {
+    expect(articleFilterReducer(initialState, filterAuthors)).toEqual({
+      ...initialState,
+      authors,
+    });
+  });
+
+  it('should handle FETCH_TAGS', () => {
+    expect(articleFilterReducer(initialState, filterTags)).toEqual({
+      ...initialState,
+      tags: tagSlugs,
+    });
+  });
+});

--- a/src/containers/FilterDropDown/state/types.js
+++ b/src/containers/FilterDropDown/state/types.js
@@ -1,0 +1,2 @@
+export const FETCH_AUTHORS = "FETCH_AUTHORS";
+export const FETCH_TAGS = "FETCH_TAGS";

--- a/src/containers/profiles/state/actions.test.js
+++ b/src/containers/profiles/state/actions.test.js
@@ -60,6 +60,13 @@ describe('user get profile actions', () => {
     });
   });
 
+  it('should get the profile of a user based on the username', () => {
+    axiosMock.onGet(getURL('profiles/beverly/')).reply(200, payload);
+    store.dispatch(actions.getUserProfileAction('beverly')).then(() => {
+      expect(store.getActions()).toContainEqual({ type: actions.USER_PROFILE_ERROR, payload });
+    });
+  });
+
   it('should edit the profile of a user based on the username', () => {
     axiosMock.onPut(getURL('profiles/beverly/')).reply(200, payload);
     store.dispatch(actions.editUserProfileAction('beverly')).then(() => {

--- a/src/pages/Search/Search.scss
+++ b/src/pages/Search/Search.scss
@@ -1,0 +1,3 @@
+.article-search {
+  padding: 1em;
+}

--- a/src/pages/Search/__snapshots__/search.test.js.snap
+++ b/src/pages/Search/__snapshots__/search.test.js.snap
@@ -1,10 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the search container renders without crashing 1`] = `
+exports[`The Search container renders without crashing 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Search
     fetchArticles={[MockFunction]}
+    filtersChanged={[MockFunction]}
+    onFilterChanged={[MockFunction]}
+    onSearch={[MockFunction]}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -27,30 +30,55 @@ ShallowWrapper {
           <div
             className="nav-wrapper"
           >
-            <form>
+            <div
+              className="article-search"
+            >
               <div
-                className="input-field"
+                className="row"
               >
-                <input
-                  name="search"
-                  onChange={[Function]}
-                  placeholder="Search here"
-                  required={true}
-                  type="search"
-                  value=""
-                />
-                <label
-                  className="label-icon"
-                  htmlFor="search"
+                <div
+                  className="input-field col s10"
                 >
-                  <i
-                    className="material-icons"
+                  <input
+                    name="search"
+                    onChange={[Function]}
+                    placeholder="Search here"
+                    required={true}
+                    type="search"
+                    value=""
+                  />
+                  <label
+                    className="label-icon"
+                    htmlFor="search"
                   >
-                    search
-                  </i>
-                </label>
+                    <i
+                      className="material-icons"
+                    >
+                      search
+                    </i>
+                  </label>
+                </div>
+                <div
+                  className="col s2"
+                >
+                  <a
+                    className="btn white-text dropdown-trigger"
+                    href="#filter-dropdown"
+                    id="filter-dropdown-trigger"
+                  >
+                    <i
+                      className="material-icons left"
+                    >
+                      filter_list
+                    </i>
+                    Filter
+                  </a>
+                </div>
               </div>
-            </form>
+            </div>
+            <Connect(FilterDropDown)
+              filtersChanged={[Function]}
+            />
           </div>
         </div>,
         <div
@@ -59,12 +87,22 @@ ShallowWrapper {
           <div
             className="row"
           >
-            <Connect(ArticleListing)
-              emptyMessage="We did not find any results"
-              initialList={5}
-              listName="search"
-              url="articles/search_filter"
-            />
+            <div
+              className="col l8 s12"
+            >
+              <Connect(ArticleListing)
+                bordered={true}
+                emptyMessage="We did not find any results"
+                initialList={5}
+                listName="search"
+                url="articles/search_filter"
+              />
+            </div>
+            <div
+              className="col l3 s12"
+            >
+              
+            </div>
           </div>
         </div>,
       ],
@@ -88,101 +126,15 @@ ShallowWrapper {
           "children": <div
             className="nav-wrapper"
           >
-            <form>
+            <div
+              className="article-search"
+            >
               <div
-                className="input-field"
+                className="row"
               >
-                <input
-                  name="search"
-                  onChange={[Function]}
-                  placeholder="Search here"
-                  required={true}
-                  type="search"
-                  value=""
-                />
-                <label
-                  className="label-icon"
-                  htmlFor="search"
+                <div
+                  className="input-field col s10"
                 >
-                  <i
-                    className="material-icons"
-                  >
-                    search
-                  </i>
-                </label>
-              </div>
-            </form>
-          </div>,
-          "className": "container",
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": <form>
-              <div
-                className="input-field"
-              >
-                <input
-                  name="search"
-                  onChange={[Function]}
-                  placeholder="Search here"
-                  required={true}
-                  type="search"
-                  value=""
-                />
-                <label
-                  className="label-icon"
-                  htmlFor="search"
-                >
-                  <i
-                    className="material-icons"
-                  >
-                    search
-                  </i>
-                </label>
-              </div>
-            </form>,
-            "className": "nav-wrapper",
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": <div
-                className="input-field"
-              >
-                <input
-                  name="search"
-                  onChange={[Function]}
-                  placeholder="Search here"
-                  required={true}
-                  type="search"
-                  value=""
-                />
-                <label
-                  className="label-icon"
-                  htmlFor="search"
-                >
-                  <i
-                    className="material-icons"
-                  >
-                    search
-                  </i>
-                </label>
-              </div>,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
                   <input
                     name="search"
                     onChange={[Function]}
@@ -190,7 +142,7 @@ ShallowWrapper {
                     required={true}
                     type="search"
                     value=""
-                  />,
+                  />
                   <label
                     className="label-icon"
                     htmlFor="search"
@@ -200,61 +152,342 @@ ShallowWrapper {
                     >
                       search
                     </i>
-                  </label>,
-                ],
-                "className": "input-field",
+                  </label>
+                </div>
+                <div
+                  className="col s2"
+                >
+                  <a
+                    className="btn white-text dropdown-trigger"
+                    href="#filter-dropdown"
+                    id="filter-dropdown-trigger"
+                  >
+                    <i
+                      className="material-icons left"
+                    >
+                      filter_list
+                    </i>
+                    Filter
+                  </a>
+                </div>
+              </div>
+            </div>
+            <Connect(FilterDropDown)
+              filtersChanged={[Function]}
+            />
+          </div>,
+          "className": "container",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <div
+                className="article-search"
+              >
+                <div
+                  className="row"
+                >
+                  <div
+                    className="input-field col s10"
+                  >
+                    <input
+                      name="search"
+                      onChange={[Function]}
+                      placeholder="Search here"
+                      required={true}
+                      type="search"
+                      value=""
+                    />
+                    <label
+                      className="label-icon"
+                      htmlFor="search"
+                    >
+                      <i
+                        className="material-icons"
+                      >
+                        search
+                      </i>
+                    </label>
+                  </div>
+                  <div
+                    className="col s2"
+                  >
+                    <a
+                      className="btn white-text dropdown-trigger"
+                      href="#filter-dropdown"
+                      id="filter-dropdown-trigger"
+                    >
+                      <i
+                        className="material-icons left"
+                      >
+                        filter_list
+                      </i>
+                      Filter
+                    </a>
+                  </div>
+                </div>
+              </div>,
+              <Connect(FilterDropDown)
+                filtersChanged={[Function]}
+              />,
+            ],
+            "className": "nav-wrapper",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="row"
+                >
+                  <div
+                    className="input-field col s10"
+                  >
+                    <input
+                      name="search"
+                      onChange={[Function]}
+                      placeholder="Search here"
+                      required={true}
+                      type="search"
+                      value=""
+                    />
+                    <label
+                      className="label-icon"
+                      htmlFor="search"
+                    >
+                      <i
+                        className="material-icons"
+                      >
+                        search
+                      </i>
+                    </label>
+                  </div>
+                  <div
+                    className="col s2"
+                  >
+                    <a
+                      className="btn white-text dropdown-trigger"
+                      href="#filter-dropdown"
+                      id="filter-dropdown-trigger"
+                    >
+                      <i
+                        className="material-icons left"
+                      >
+                        filter_list
+                      </i>
+                      Filter
+                    </a>
+                  </div>
+                </div>,
+                "className": "article-search",
               },
               "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "name": "search",
-                    "onChange": [Function],
-                    "placeholder": "Search here",
-                    "required": true,
-                    "type": "search",
-                    "value": "",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": "input",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <i
-                      className="material-icons"
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <div
+                      className="input-field col s10"
                     >
-                      search
-                    </i>,
-                    "className": "label-icon",
-                    "htmlFor": "search",
-                  },
-                  "ref": null,
-                  "rendered": Object {
+                      <input
+                        name="search"
+                        onChange={[Function]}
+                        placeholder="Search here"
+                        required={true}
+                        type="search"
+                        value=""
+                      />
+                      <label
+                        className="label-icon"
+                        htmlFor="search"
+                      >
+                        <i
+                          className="material-icons"
+                        >
+                          search
+                        </i>
+                      </label>
+                    </div>,
+                    <div
+                      className="col s2"
+                    >
+                      <a
+                        className="btn white-text dropdown-trigger"
+                        href="#filter-dropdown"
+                        id="filter-dropdown-trigger"
+                      >
+                        <i
+                          className="material-icons left"
+                        >
+                          filter_list
+                        </i>
+                        Filter
+                      </a>
+                    </div>,
+                  ],
+                  "className": "row",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
                     "instance": null,
                     "key": undefined,
                     "nodeType": "host",
                     "props": Object {
-                      "children": "search",
-                      "className": "material-icons",
+                      "children": Array [
+                        <input
+                          name="search"
+                          onChange={[Function]}
+                          placeholder="Search here"
+                          required={true}
+                          type="search"
+                          value=""
+                        />,
+                        <label
+                          className="label-icon"
+                          htmlFor="search"
+                        >
+                          <i
+                            className="material-icons"
+                          >
+                            search
+                          </i>
+                        </label>,
+                      ],
+                      "className": "input-field col s10",
                     },
                     "ref": null,
-                    "rendered": "search",
-                    "type": "i",
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "name": "search",
+                          "onChange": [Function],
+                          "placeholder": "Search here",
+                          "required": true,
+                          "type": "search",
+                          "value": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": "input",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <i
+                            className="material-icons"
+                          >
+                            search
+                          </i>,
+                          "className": "label-icon",
+                          "htmlFor": "search",
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "search",
+                            "className": "material-icons",
+                          },
+                          "ref": null,
+                          "rendered": "search",
+                          "type": "i",
+                        },
+                        "type": "label",
+                      },
+                    ],
+                    "type": "div",
                   },
-                  "type": "label",
-                },
-              ],
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <a
+                        className="btn white-text dropdown-trigger"
+                        href="#filter-dropdown"
+                        id="filter-dropdown-trigger"
+                      >
+                        <i
+                          className="material-icons left"
+                        >
+                          filter_list
+                        </i>
+                        Filter
+                      </a>,
+                      "className": "col s2",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <i
+                            className="material-icons left"
+                          >
+                            filter_list
+                          </i>,
+                          "Filter",
+                        ],
+                        "className": "btn white-text dropdown-trigger",
+                        "href": "#filter-dropdown",
+                        "id": "filter-dropdown-trigger",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "filter_list",
+                            "className": "material-icons left",
+                          },
+                          "ref": null,
+                          "rendered": "filter_list",
+                          "type": "i",
+                        },
+                        "Filter",
+                      ],
+                      "type": "a",
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
               "type": "div",
             },
-            "type": "form",
-          },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "filtersChanged": [Function],
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+          ],
           "type": "div",
         },
         "type": "div",
@@ -267,12 +500,22 @@ ShallowWrapper {
           "children": <div
             className="row"
           >
-            <Connect(ArticleListing)
-              emptyMessage="We did not find any results"
-              initialList={5}
-              listName="search"
-              url="articles/search_filter"
-            />
+            <div
+              className="col l8 s12"
+            >
+              <Connect(ArticleListing)
+                bordered={true}
+                emptyMessage="We did not find any results"
+                initialList={5}
+                listName="search"
+                url="articles/search_filter"
+              />
+            </div>
+            <div
+              className="col l3 s12"
+            >
+              
+            </div>
           </div>,
           "className": "container",
         },
@@ -282,29 +525,73 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <Connect(ArticleListing)
-              emptyMessage="We did not find any results"
-              initialList={5}
-              listName="search"
-              url="articles/search_filter"
-            />,
+            "children": Array [
+              <div
+                className="col l8 s12"
+              >
+                <Connect(ArticleListing)
+                  bordered={true}
+                  emptyMessage="We did not find any results"
+                  initialList={5}
+                  listName="search"
+                  url="articles/search_filter"
+                />
+              </div>,
+              <div
+                className="col l3 s12"
+              >
+                
+              </div>,
+            ],
             "className": "row",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "emptyMessage": "We did not find any results",
-              "initialList": 5,
-              "listName": "search",
-              "url": "articles/search_filter",
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <Connect(ArticleListing)
+                  bordered={true}
+                  emptyMessage="We did not find any results"
+                  initialList={5}
+                  listName="search"
+                  url="articles/search_filter"
+                />,
+                "className": "col l8 s12",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "bordered": true,
+                  "emptyMessage": "We did not find any results",
+                  "initialList": 5,
+                  "listName": "search",
+                  "url": "articles/search_filter",
+                },
+                "ref": [Function],
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "div",
             },
-            "ref": [Function],
-            "rendered": null,
-            "type": [Function],
-          },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "",
+                "className": "col l3 s12",
+              },
+              "ref": null,
+              "rendered": "",
+              "type": "div",
+            },
+          ],
           "type": "div",
         },
         "type": "div",
@@ -326,30 +613,55 @@ ShallowWrapper {
             <div
               className="nav-wrapper"
             >
-              <form>
+              <div
+                className="article-search"
+              >
                 <div
-                  className="input-field"
+                  className="row"
                 >
-                  <input
-                    name="search"
-                    onChange={[Function]}
-                    placeholder="Search here"
-                    required={true}
-                    type="search"
-                    value=""
-                  />
-                  <label
-                    className="label-icon"
-                    htmlFor="search"
+                  <div
+                    className="input-field col s10"
                   >
-                    <i
-                      className="material-icons"
+                    <input
+                      name="search"
+                      onChange={[Function]}
+                      placeholder="Search here"
+                      required={true}
+                      type="search"
+                      value=""
+                    />
+                    <label
+                      className="label-icon"
+                      htmlFor="search"
                     >
-                      search
-                    </i>
-                  </label>
+                      <i
+                        className="material-icons"
+                      >
+                        search
+                      </i>
+                    </label>
+                  </div>
+                  <div
+                    className="col s2"
+                  >
+                    <a
+                      className="btn white-text dropdown-trigger"
+                      href="#filter-dropdown"
+                      id="filter-dropdown-trigger"
+                    >
+                      <i
+                        className="material-icons left"
+                      >
+                        filter_list
+                      </i>
+                      Filter
+                    </a>
+                  </div>
                 </div>
-              </form>
+              </div>
+              <Connect(FilterDropDown)
+                filtersChanged={[Function]}
+              />
             </div>
           </div>,
           <div
@@ -358,12 +670,22 @@ ShallowWrapper {
             <div
               className="row"
             >
-              <Connect(ArticleListing)
-                emptyMessage="We did not find any results"
-                initialList={5}
-                listName="search"
-                url="articles/search_filter"
-              />
+              <div
+                className="col l8 s12"
+              >
+                <Connect(ArticleListing)
+                  bordered={true}
+                  emptyMessage="We did not find any results"
+                  initialList={5}
+                  listName="search"
+                  url="articles/search_filter"
+                />
+              </div>
+              <div
+                className="col l3 s12"
+              >
+                
+              </div>
             </div>
           </div>,
         ],
@@ -387,101 +709,15 @@ ShallowWrapper {
             "children": <div
               className="nav-wrapper"
             >
-              <form>
+              <div
+                className="article-search"
+              >
                 <div
-                  className="input-field"
+                  className="row"
                 >
-                  <input
-                    name="search"
-                    onChange={[Function]}
-                    placeholder="Search here"
-                    required={true}
-                    type="search"
-                    value=""
-                  />
-                  <label
-                    className="label-icon"
-                    htmlFor="search"
+                  <div
+                    className="input-field col s10"
                   >
-                    <i
-                      className="material-icons"
-                    >
-                      search
-                    </i>
-                  </label>
-                </div>
-              </form>
-            </div>,
-            "className": "container",
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": <form>
-                <div
-                  className="input-field"
-                >
-                  <input
-                    name="search"
-                    onChange={[Function]}
-                    placeholder="Search here"
-                    required={true}
-                    type="search"
-                    value=""
-                  />
-                  <label
-                    className="label-icon"
-                    htmlFor="search"
-                  >
-                    <i
-                      className="material-icons"
-                    >
-                      search
-                    </i>
-                  </label>
-                </div>
-              </form>,
-              "className": "nav-wrapper",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": <div
-                  className="input-field"
-                >
-                  <input
-                    name="search"
-                    onChange={[Function]}
-                    placeholder="Search here"
-                    required={true}
-                    type="search"
-                    value=""
-                  />
-                  <label
-                    className="label-icon"
-                    htmlFor="search"
-                  >
-                    <i
-                      className="material-icons"
-                    >
-                      search
-                    </i>
-                  </label>
-                </div>,
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
                     <input
                       name="search"
                       onChange={[Function]}
@@ -489,7 +725,7 @@ ShallowWrapper {
                       required={true}
                       type="search"
                       value=""
-                    />,
+                    />
                     <label
                       className="label-icon"
                       htmlFor="search"
@@ -499,61 +735,342 @@ ShallowWrapper {
                       >
                         search
                       </i>
-                    </label>,
-                  ],
-                  "className": "input-field",
+                    </label>
+                  </div>
+                  <div
+                    className="col s2"
+                  >
+                    <a
+                      className="btn white-text dropdown-trigger"
+                      href="#filter-dropdown"
+                      id="filter-dropdown-trigger"
+                    >
+                      <i
+                        className="material-icons left"
+                      >
+                        filter_list
+                      </i>
+                      Filter
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <Connect(FilterDropDown)
+                filtersChanged={[Function]}
+              />
+            </div>,
+            "className": "container",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <div
+                  className="article-search"
+                >
+                  <div
+                    className="row"
+                  >
+                    <div
+                      className="input-field col s10"
+                    >
+                      <input
+                        name="search"
+                        onChange={[Function]}
+                        placeholder="Search here"
+                        required={true}
+                        type="search"
+                        value=""
+                      />
+                      <label
+                        className="label-icon"
+                        htmlFor="search"
+                      >
+                        <i
+                          className="material-icons"
+                        >
+                          search
+                        </i>
+                      </label>
+                    </div>
+                    <div
+                      className="col s2"
+                    >
+                      <a
+                        className="btn white-text dropdown-trigger"
+                        href="#filter-dropdown"
+                        id="filter-dropdown-trigger"
+                      >
+                        <i
+                          className="material-icons left"
+                        >
+                          filter_list
+                        </i>
+                        Filter
+                      </a>
+                    </div>
+                  </div>
+                </div>,
+                <Connect(FilterDropDown)
+                  filtersChanged={[Function]}
+                />,
+              ],
+              "className": "nav-wrapper",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div
+                    className="row"
+                  >
+                    <div
+                      className="input-field col s10"
+                    >
+                      <input
+                        name="search"
+                        onChange={[Function]}
+                        placeholder="Search here"
+                        required={true}
+                        type="search"
+                        value=""
+                      />
+                      <label
+                        className="label-icon"
+                        htmlFor="search"
+                      >
+                        <i
+                          className="material-icons"
+                        >
+                          search
+                        </i>
+                      </label>
+                    </div>
+                    <div
+                      className="col s2"
+                    >
+                      <a
+                        className="btn white-text dropdown-trigger"
+                        href="#filter-dropdown"
+                        id="filter-dropdown-trigger"
+                      >
+                        <i
+                          className="material-icons left"
+                        >
+                          filter_list
+                        </i>
+                        Filter
+                      </a>
+                    </div>
+                  </div>,
+                  "className": "article-search",
                 },
                 "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "name": "search",
-                      "onChange": [Function],
-                      "placeholder": "Search here",
-                      "required": true,
-                      "type": "search",
-                      "value": "",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": "input",
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": <i
-                        className="material-icons"
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <div
+                        className="input-field col s10"
                       >
-                        search
-                      </i>,
-                      "className": "label-icon",
-                      "htmlFor": "search",
-                    },
-                    "ref": null,
-                    "rendered": Object {
+                        <input
+                          name="search"
+                          onChange={[Function]}
+                          placeholder="Search here"
+                          required={true}
+                          type="search"
+                          value=""
+                        />
+                        <label
+                          className="label-icon"
+                          htmlFor="search"
+                        >
+                          <i
+                            className="material-icons"
+                          >
+                            search
+                          </i>
+                        </label>
+                      </div>,
+                      <div
+                        className="col s2"
+                      >
+                        <a
+                          className="btn white-text dropdown-trigger"
+                          href="#filter-dropdown"
+                          id="filter-dropdown-trigger"
+                        >
+                          <i
+                            className="material-icons left"
+                          >
+                            filter_list
+                          </i>
+                          Filter
+                        </a>
+                      </div>,
+                    ],
+                    "className": "row",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
                       "instance": null,
                       "key": undefined,
                       "nodeType": "host",
                       "props": Object {
-                        "children": "search",
-                        "className": "material-icons",
+                        "children": Array [
+                          <input
+                            name="search"
+                            onChange={[Function]}
+                            placeholder="Search here"
+                            required={true}
+                            type="search"
+                            value=""
+                          />,
+                          <label
+                            className="label-icon"
+                            htmlFor="search"
+                          >
+                            <i
+                              className="material-icons"
+                            >
+                              search
+                            </i>
+                          </label>,
+                        ],
+                        "className": "input-field col s10",
                       },
                       "ref": null,
-                      "rendered": "search",
-                      "type": "i",
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "name": "search",
+                            "onChange": [Function],
+                            "placeholder": "Search here",
+                            "required": true,
+                            "type": "search",
+                            "value": "",
+                          },
+                          "ref": null,
+                          "rendered": null,
+                          "type": "input",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <i
+                              className="material-icons"
+                            >
+                              search
+                            </i>,
+                            "className": "label-icon",
+                            "htmlFor": "search",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "search",
+                              "className": "material-icons",
+                            },
+                            "ref": null,
+                            "rendered": "search",
+                            "type": "i",
+                          },
+                          "type": "label",
+                        },
+                      ],
+                      "type": "div",
                     },
-                    "type": "label",
-                  },
-                ],
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <a
+                          className="btn white-text dropdown-trigger"
+                          href="#filter-dropdown"
+                          id="filter-dropdown-trigger"
+                        >
+                          <i
+                            className="material-icons left"
+                          >
+                            filter_list
+                          </i>
+                          Filter
+                        </a>,
+                        "className": "col s2",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            <i
+                              className="material-icons left"
+                            >
+                              filter_list
+                            </i>,
+                            "Filter",
+                          ],
+                          "className": "btn white-text dropdown-trigger",
+                          "href": "#filter-dropdown",
+                          "id": "filter-dropdown-trigger",
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": "filter_list",
+                              "className": "material-icons left",
+                            },
+                            "ref": null,
+                            "rendered": "filter_list",
+                            "type": "i",
+                          },
+                          "Filter",
+                        ],
+                        "type": "a",
+                      },
+                      "type": "div",
+                    },
+                  ],
+                  "type": "div",
+                },
                 "type": "div",
               },
-              "type": "form",
-            },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "filtersChanged": [Function],
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+            ],
             "type": "div",
           },
           "type": "div",
@@ -566,12 +1083,22 @@ ShallowWrapper {
             "children": <div
               className="row"
             >
-              <Connect(ArticleListing)
-                emptyMessage="We did not find any results"
-                initialList={5}
-                listName="search"
-                url="articles/search_filter"
-              />
+              <div
+                className="col l8 s12"
+              >
+                <Connect(ArticleListing)
+                  bordered={true}
+                  emptyMessage="We did not find any results"
+                  initialList={5}
+                  listName="search"
+                  url="articles/search_filter"
+                />
+              </div>
+              <div
+                className="col l3 s12"
+              >
+                
+              </div>
             </div>,
             "className": "container",
           },
@@ -581,29 +1108,73 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": <Connect(ArticleListing)
-                emptyMessage="We did not find any results"
-                initialList={5}
-                listName="search"
-                url="articles/search_filter"
-              />,
+              "children": Array [
+                <div
+                  className="col l8 s12"
+                >
+                  <Connect(ArticleListing)
+                    bordered={true}
+                    emptyMessage="We did not find any results"
+                    initialList={5}
+                    listName="search"
+                    url="articles/search_filter"
+                  />
+                </div>,
+                <div
+                  className="col l3 s12"
+                >
+                  
+                </div>,
+              ],
               "className": "row",
             },
             "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "emptyMessage": "We did not find any results",
-                "initialList": 5,
-                "listName": "search",
-                "url": "articles/search_filter",
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <Connect(ArticleListing)
+                    bordered={true}
+                    emptyMessage="We did not find any results"
+                    initialList={5}
+                    listName="search"
+                    url="articles/search_filter"
+                  />,
+                  "className": "col l8 s12",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "bordered": true,
+                    "emptyMessage": "We did not find any results",
+                    "initialList": 5,
+                    "listName": "search",
+                    "url": "articles/search_filter",
+                  },
+                  "ref": [Function],
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": "div",
               },
-              "ref": [Function],
-              "rendered": null,
-              "type": [Function],
-            },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "",
+                  "className": "col l3 s12",
+                },
+                "ref": null,
+                "rendered": "",
+                "type": "div",
+              },
+            ],
             "type": "div",
           },
           "type": "div",

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -5,48 +5,115 @@ import { connect } from 'react-redux';
 import NavBar from '../../containers/NavBar';
 import { articlesFetchAction } from '../../containers/ArticleListing/state/actions';
 import ConnectedArticleListing from '../../containers/ArticleListing';
+import FilterDropDown from '../../containers/FilterDropDown';
+import './Search.scss';
+import profile from '../../assets/images/profile.jpg';
 
 export class Search extends Component {
+    timeout = null;
+
     state ={
       search: '',
-    };
+      tag: '',
+      username: '',
+      author: {},
+    }
 
     onSearch = (e) => {
-      const { fetchArticles } = this.props;
       this.setState({ [e.target.name]: e.target.value });
-      fetchArticles("articles/search_filter", { ...this.state }, "search");
-    };
+      clearTimeout(this.timeout);
+
+      this.timeout = setTimeout(() => {
+        const { fetchArticles } = this.props;
+        fetchArticles("articles/search_filter", { ...this.state }, "search");
+      }, 500);
+    }
+
+    onFilterChanged = (tag, author) => {
+      const { fetchArticles } = this.props;
+      this.setState({ tag, username: author ? author.username : '', author });
+
+      fetchArticles("articles/search_filter",
+        { ...this.state, tag, username: author ? author.username : '' },
+        "search");
+    }
+
+    renderFilters = (author, tag) => (
+      <div className="card">
+        <div className="card-content">
+          <h4>Filters</h4>
+          {
+            author && author.username && (
+              <div>
+                <h6>Author</h6>
+                <div className="chip">
+                  <img src={author.image || profile} alt={author.username} />
+                  {author.username}
+                </div>
+              </div>
+            )
+          }
+          {
+            tag && (
+              <>
+                <h6>Tag</h6>
+                <div className="chip">
+                  {tag}
+                </div>
+              </>
+            )
+          }
+        </div>
+      </div>
+    )
 
     render() {
+      const { author, tag } = this.state;
       return (
         <div>
           <NavBar />
           <div className="container">
             <div className="nav-wrapper">
-              <form>
-                <div className="input-field">
-                  <input type="search" name="search" required placeholder="Search here" onChange={this.onSearch} value={this.state.search} />
-                  <label className="label-icon" htmlFor="search"><i className="material-icons">search</i></label>
+              <div className="article-search">
+                <div className="row">
+                  <div className="input-field col s10">
+                    <input type="search" name="search" required placeholder="Search here" onChange={this.onSearch} value={this.state.search} />
+                    <label className="label-icon" htmlFor="search"><i className="material-icons">search</i></label>
+                  </div>
+                  <div className="col s2">
+                    <a href="#filter-dropdown" className="btn white-text dropdown-trigger" id="filter-dropdown-trigger">
+                      <i className="material-icons left">filter_list</i>
+                    Filter
+                    </a>
+                  </div>
                 </div>
-              </form>
+              </div>
+              <FilterDropDown filtersChanged={this.onFilterChanged} />
             </div>
           </div>
           <div className="container">
             <div className="row">
-              <ConnectedArticleListing
-                ref={(list) => { this.list = list; }}
-                initialList={5}
-                emptyMessage="We did not find any results"
-                listName="search"
-                url="articles/search_filter"
-              />
+              <div className="col l8 s12">
+                <ConnectedArticleListing
+                  ref={(list) => { this.list = list; }}
+                  initialList={5}
+                  bordered
+                  emptyMessage="We did not find any results"
+                  listName="search"
+                  url="articles/search_filter"
+                />
+              </div>
+              <div className="col l3 s12">
+                {
+                  ((author && author.username) || tag) && this.renderFilters(author, tag)
+                }
+              </div>
             </div>
           </div>
         </div>
       );
     }
 }
-
 
 Search.propTypes = {
   fetchArticles: PropTypes.func.isRequired,

--- a/src/pages/Search/search.test.js
+++ b/src/pages/Search/search.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
-
 import { Search } from './index';
 import mockStore from '../../utils/redux_mock_store';
 
@@ -9,9 +8,14 @@ const store = mockStore();
 
 const props = {
   fetchArticles: jest.fn(),
+  onSearch: jest.fn(),
+  onFilterChanged: jest.fn(),
+  filtersChanged: jest.fn(),
 };
 
-describe('the search container', () => {
+jest.useFakeTimers();
+
+describe('The Search container', () => {
   const wrapper = mount(<Provider store={store}><Search {...props} /></Provider>);
 
   beforeEach(() => {
@@ -24,7 +28,8 @@ describe('the search container', () => {
   });
 
   it('receive props', () => {
-    expect(wrapper.props()).toBeTruthy();
+    wrapper.find(Search).setState({ tag: 'tag' });
+    expect(wrapper.find('.card').length).toEqual(1);
   });
 
   it('always renders a div', () => {
@@ -32,23 +37,30 @@ describe('the search container', () => {
     expect(divs).toBeDefined();
   });
 
-  it('renders a Navbar component', () => {
+  it('always renders a <ConnectedArticleListing/>', () => {
     const NavBar = wrapper.find('Navbar');
     expect(NavBar).toBeTruthy();
   });
 
-  it('renders a ConnectedArticleListing component', () => {
+  it('always renders a <ConnectedArticleListing/>', () => {
     const ArticleListing = wrapper.find('ArticleListing');
     expect(ArticleListing).toBeTruthy();
   });
 
-  it('renders a search icon', () => {
-    const icon = wrapper.find('i').text();
-    expect(icon).toBe('search');
+  it('calls onSearch method', () => {
+    wrapper.find('input').at(0).simulate('change', { target: { value: 'searchme' } });
+    expect(props.fetchArticles.mock.calls.length).toEqual(0);
+    jest.runAllTimers();
+    expect(setTimeout).toHaveBeenCalled();
   });
 
-  it('calls onSearch method', () => {
-    wrapper.find('input').simulate('change');
-    expect(props.fetchArticles).toHaveBeenCalled();
+  it('should filter articles when user stops typing', () => {
+    wrapper.find('button').at(1).simulate('click');
+    expect(props.filtersChanged.mock.calls.length).toEqual(0);
+  });
+
+  it('always renders a <FilterDropDown />', () => {
+    const FilterDropDown = wrapper.find('FilteDropDown');
+    expect(FilterDropDown).toBeTruthy();
   });
 });

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -18,10 +18,11 @@ import subscribe from "../containers/Subscribe/state/reducer";
 import rate from "../containers/Rating/state/reducer";
 import ratingStats from "../containers/RatingStats/state/reducer";
 import favorite from "../containers/ArticleFavoriting/state/reducers";
-import stats from "../containers/Stats/state/reducer";
 import follow from "../containers/FollowUnfollow/state/reducer";
 import usersListing from "../containers/UsersListing/state/reducer";
 import network from '../containers/NetworkPopup/state/reducer';
+import stats from '../containers/Stats/state/reducer';
+import filterArticles from '../containers/FilterDropDown/state/reducer';
 
 const rootReducer = combineReducers({
   article,
@@ -47,6 +48,7 @@ const rootReducer = combineReducers({
   follow,
   usersListing,
   network,
+  filterArticles,
 });
 
 export default rootReducer;


### PR DESCRIPTION
**What does this PR do?**

It enables users to filter articles using specific parameters.

**Description of Task to be completed?**

Users may want to get desired articles quickly. This PR allows them to filter articles using parameters i.e tags and authors' usernames.

**How should this be manually tested?**

- Open this PR's review app
- Click on the search icon in the Navbar
- Click on filter icon
- Fill details, i.e tag or author or both
- The articles should appear as desired i.e (you will get articles by your desired author or tags)

**Any background context you want to provide?**

This feature is heavily integrated with the search feature. By this I mean that one can filter using a parameter and then search anything on the results that will be provided.

**What are the relevant pivotal tracker stories?**

https://www.pivotaltracker.com/story/show/160577586

**Screenshots (if appropriate)**

This is what you see when you navigate to the search page
<img width="1440" alt="screen shot 2018-11-29 at 11 29 29" src="https://user-images.githubusercontent.com/26184534/49208926-3270d980-f3ca-11e8-9d40-e586f3b414b5.png">

Input the filter parameters. There is also autocomplete as a user types
<img width="1440" alt="screen shot 2018-11-29 at 11 29 55" src="https://user-images.githubusercontent.com/26184534/49209044-7237c100-f3ca-11e8-995f-23c5f76b13d4.png">

Click apply and the articles should appear on your right
<img width="1440" alt="screen shot 2018-11-29 at 11 30 09" src="https://user-images.githubusercontent.com/26184534/49209113-a57a5000-f3ca-11e8-891b-eea3a5a7a082.png">

**Questions:**

N/A