### PR TITLE
#162335550 Fix edit profile save button invisible

### DIFF
--- a/src/containers/profiles/EditProfiles/index.js
+++ b/src/containers/profiles/EditProfiles/index.js
@@ -69,7 +69,7 @@ class EditProfiles extends Component {
             </div>
             <div className="edit-profile">
               <form onSubmit={this.handleSubmit}>
-                <textarea name="bio" onChange={this.onChange} maxLength="200" placeholder="Bio" id="bio" cols="100" rows="80" value={this.state.bio} />
+                <textarea name="bio" onChange={this.onChange} maxLength="200" placeholder="Bio" id="bio" cols="100" rows="5" value={this.state.bio} />
                 <input name="images" onChange={this.onChange} type="file" id="upload-image" style={{ visibility: 'hidden' }} />
                 <div className="right">
                   <a href="#!" className="modal-close waves-effect white btn-flat">Cancel</a>


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug that causes the Save button on edit profile modal to be invisible to the user.

**Description of Task to be completed?**

##### Steps to reproduce
1. Open MyProfile
2. Click the edit button. A modal for editing profile appears.

##### Expected
Users should see the Save button.

##### Actual
Users do not see the Save button. One has to scroll down over a huge blank space to see it.

**How should this be manually tested?**

This can be manually tested by runnning this PR's review app and editing a profile.

**What are the relevant pivotal tracker stories?**

[#162335550](https://www.pivotaltracker.com/story/show/162335550)

**Screenshots (if appropriate)**

Before
<img width="820" alt="screen shot 2018-11-30 at 07 11 33" src="https://user-images.githubusercontent.com/8180548/49268487-c85f3f80-f470-11e8-9996-09c314d3c587.png">

After
<img width="872" alt="screen shot 2018-11-30 at 07 24 00" src="https://user-images.githubusercontent.com/8180548/49268520-f2186680-f470-11e8-86e5-c7e0381fd376.png">