### PR TITLE
#162335831 Fix report article freezing page

### DIFF
--- a/src/containers/ReportArticle/ReportArticle.scss
+++ b/src/containers/ReportArticle/ReportArticle.scss
@@ -1,0 +1,3 @@
+.cancel-report {
+  margin-right: .5em;
+}

--- a/src/containers/ReportArticle/ReportArticle.test.js
+++ b/src/containers/ReportArticle/ReportArticle.test.js
@@ -60,7 +60,7 @@ describe('The ReportArticle container', () => {
   });
 
   it('should call reportArticle action after onClick event', () => {
-    wrapper.find('button').simulate('click', {
+    wrapper.find('.submit-report').simulate('click', {
       target: {},
     });
     expect(props.reportArticle).toHaveBeenCalledTimes(1);

--- a/src/containers/ReportArticle/index.js
+++ b/src/containers/ReportArticle/index.js
@@ -6,6 +6,7 @@ import Modal from "../../components/Modal";
 import DropDown from "../../components/DropDown";
 import DropDownItem from "../../components/DropDownItem";
 import { REPORT_WITHOUT_DATA } from './state/types';
+import './ReportArticle.scss';
 
 
 export class ReportArticle extends Component {
@@ -15,11 +16,11 @@ export class ReportArticle extends Component {
   }
 
   componentDidMount = () => {
-    Materialize.Modal.init(document.querySelector('#report-modal'), {});
+    Materialize.Modal.init(document.querySelector('#report-modal'), { dismissible: false });
   };
 
   componentDidUpdate = () => {
-    Materialize.FormSelect.init(document.querySelectorAll('select'), {});
+    Materialize.FormSelect.init(document.querySelectorAll('#report-selection'), {});
   };
 
 
@@ -70,14 +71,22 @@ export class ReportArticle extends Component {
         title="Report this article"
         fixedFooter
         footer={(
-          <button
-            id="report-button"
-            className="right btn-bordered"
-            type="submit"
-            onClick={this.handleSubmit}
-          >
+          <div className="right">
+            <button
+              type="button"
+              className="btn-bordered cancel-report modal-close"
+            >
+              Cancel
+            </button>
+            <button
+              id="report-button"
+              className="btn-bordered submit-report modal-close"
+              type="submit"
+              onClick={this.handleSubmit}
+            >
             Report
-          </button>
+            </button>
+          </div>
         )}
       >
         <form action="">


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug that causes the page to freeze after the user has reported an article.

**Description of Task to be completed?**

##### Steps to reproduce
1. Log in
2. Open any article
3. Report it

##### Expected
After the report is submitted the page should be scrollable.

##### Actual
After the report is submitted the page no longer scrolls.

**How should this be manually tested?**

This can be manually tested by running this PR's review app and reporting an article.

**Any background context you want to provide?**

The problem is caused by an unclosed modal. The report button does not have a `close-modal` class required by `Materialize` to close modals.

**What are the relevant pivotal tracker stories?**

[#162335831](https://www.pivotaltracker.com/story/show/162335831)

**Screenshots**
<img width="815" alt="screen shot 2018-11-30 at 08 25 12" src="https://user-images.githubusercontent.com/8180548/49270261-8981b780-f479-11e8-91ba-fcb7c615b62a.png">