### PR TITLE
#162339528 Fix profile navigation inconsistencies

### DIFF
--- a/src/components/ArticleProfileView/__snapshots__/ArticleProfileView.test.js.snap
+++ b/src/components/ArticleProfileView/__snapshots__/ArticleProfileView.test.js.snap
@@ -108,7 +108,7 @@ ShallowWrapper {
                   >
                     <h6>
                       <a
-                        href="/profiles/view/gitaumoses4/"
+                        href="/profiles/view/gitaumoses4"
                       >
                         gitaumoses4
                       </a>
@@ -205,7 +205,7 @@ ShallowWrapper {
                     >
                       <h6>
                         <a
-                          href="/profiles/view/gitaumoses4/"
+                          href="/profiles/view/gitaumoses4"
                         >
                           gitaumoses4
                         </a>
@@ -299,7 +299,7 @@ ShallowWrapper {
                     >
                       <h6>
                         <a
-                          href="/profiles/view/gitaumoses4/"
+                          href="/profiles/view/gitaumoses4"
                         >
                           gitaumoses4
                         </a>
@@ -379,7 +379,7 @@ ShallowWrapper {
                       >
                         <h6>
                           <a
-                            href="/profiles/view/gitaumoses4/"
+                            href="/profiles/view/gitaumoses4"
                           >
                             gitaumoses4
                           </a>
@@ -511,7 +511,7 @@ ShallowWrapper {
                         >
                           <h6>
                             <a
-                              href="/profiles/view/gitaumoses4/"
+                              href="/profiles/view/gitaumoses4"
                             >
                               gitaumoses4
                             </a>
@@ -585,7 +585,7 @@ ShallowWrapper {
                         >
                           <h6>
                             <a
-                              href="/profiles/view/gitaumoses4/"
+                              href="/profiles/view/gitaumoses4"
                             >
                               gitaumoses4
                             </a>
@@ -626,7 +626,7 @@ ShallowWrapper {
                           >
                             <h6>
                               <a
-                                href="/profiles/view/gitaumoses4/"
+                                href="/profiles/view/gitaumoses4"
                               >
                                 gitaumoses4
                               </a>
@@ -666,7 +666,7 @@ ShallowWrapper {
                             "children": Array [
                               <h6>
                                 <a
-                                  href="/profiles/view/gitaumoses4/"
+                                  href="/profiles/view/gitaumoses4"
                                 >
                                   gitaumoses4
                                 </a>
@@ -702,7 +702,7 @@ ShallowWrapper {
                               "nodeType": "host",
                               "props": Object {
                                 "children": <a
-                                  href="/profiles/view/gitaumoses4/"
+                                  href="/profiles/view/gitaumoses4"
                                 >
                                   gitaumoses4
                                 </a>,
@@ -714,7 +714,7 @@ ShallowWrapper {
                                 "nodeType": "host",
                                 "props": Object {
                                   "children": "gitaumoses4",
-                                  "href": "/profiles/view/gitaumoses4/",
+                                  "href": "/profiles/view/gitaumoses4",
                                 },
                                 "ref": null,
                                 "rendered": "gitaumoses4",
@@ -879,7 +879,7 @@ ShallowWrapper {
                     >
                       <h6>
                         <a
-                          href="/profiles/view/gitaumoses4/"
+                          href="/profiles/view/gitaumoses4"
                         >
                           gitaumoses4
                         </a>
@@ -976,7 +976,7 @@ ShallowWrapper {
                       >
                         <h6>
                           <a
-                            href="/profiles/view/gitaumoses4/"
+                            href="/profiles/view/gitaumoses4"
                           >
                             gitaumoses4
                           </a>
@@ -1070,7 +1070,7 @@ ShallowWrapper {
                       >
                         <h6>
                           <a
-                            href="/profiles/view/gitaumoses4/"
+                            href="/profiles/view/gitaumoses4"
                           >
                             gitaumoses4
                           </a>
@@ -1150,7 +1150,7 @@ ShallowWrapper {
                         >
                           <h6>
                             <a
-                              href="/profiles/view/gitaumoses4/"
+                              href="/profiles/view/gitaumoses4"
                             >
                               gitaumoses4
                             </a>
@@ -1282,7 +1282,7 @@ ShallowWrapper {
                           >
                             <h6>
                               <a
-                                href="/profiles/view/gitaumoses4/"
+                                href="/profiles/view/gitaumoses4"
                               >
                                 gitaumoses4
                               </a>
@@ -1356,7 +1356,7 @@ ShallowWrapper {
                           >
                             <h6>
                               <a
-                                href="/profiles/view/gitaumoses4/"
+                                href="/profiles/view/gitaumoses4"
                               >
                                 gitaumoses4
                               </a>
@@ -1397,7 +1397,7 @@ ShallowWrapper {
                             >
                               <h6>
                                 <a
-                                  href="/profiles/view/gitaumoses4/"
+                                  href="/profiles/view/gitaumoses4"
                                 >
                                   gitaumoses4
                                 </a>
@@ -1437,7 +1437,7 @@ ShallowWrapper {
                               "children": Array [
                                 <h6>
                                   <a
-                                    href="/profiles/view/gitaumoses4/"
+                                    href="/profiles/view/gitaumoses4"
                                   >
                                     gitaumoses4
                                   </a>
@@ -1473,7 +1473,7 @@ ShallowWrapper {
                                 "nodeType": "host",
                                 "props": Object {
                                   "children": <a
-                                    href="/profiles/view/gitaumoses4/"
+                                    href="/profiles/view/gitaumoses4"
                                   >
                                     gitaumoses4
                                   </a>,
@@ -1485,7 +1485,7 @@ ShallowWrapper {
                                   "nodeType": "host",
                                   "props": Object {
                                     "children": "gitaumoses4",
-                                    "href": "/profiles/view/gitaumoses4/",
+                                    "href": "/profiles/view/gitaumoses4",
                                   },
                                   "ref": null,
                                   "rendered": "gitaumoses4",

--- a/src/components/ArticleProfileView/index.js
+++ b/src/components/ArticleProfileView/index.js
@@ -30,7 +30,7 @@ class ArticleProfileView extends React.Component {
       <div className="col">
         <div className="row">
           <div className="col">
-            <h6><a href={`/profiles/view/${article.author.username}/`}>{article.author.username || (user && user.username)}</a></h6>
+            <h6><a href={`/profiles/view/${article.author.username}`}>{article.author.username || (user && user.username)}</a></h6>
             <span className="grey-text meta">
               <Moment fromNow interval={30000}>
                 {article.created_at}

--- a/src/components/ProfileView/__snapshots__/ProfileView.test.js.snap
+++ b/src/components/ProfileView/__snapshots__/ProfileView.test.js.snap
@@ -50,7 +50,7 @@ ShallowWrapper {
               >
                 <a
                   className="green-text"
-                  href="/profiles/view/undefined/"
+                  href="/profiles/view/undefined"
                 />
               </span>
             </div>
@@ -95,7 +95,7 @@ ShallowWrapper {
               >
                 <a
                   className="green-text"
-                  href="/profiles/view/undefined/"
+                  href="/profiles/view/undefined"
                 />
               </span>
             </div>
@@ -137,7 +137,7 @@ ShallowWrapper {
               >
                 <a
                   className="green-text"
-                  href="/profiles/view/undefined/"
+                  href="/profiles/view/undefined"
                 />
               </span>
             </div>
@@ -176,7 +176,7 @@ ShallowWrapper {
                 >
                   <a
                     className="green-text"
-                    href="/profiles/view/undefined/"
+                    href="/profiles/view/undefined"
                   />
                 </span>
               </div>,
@@ -213,7 +213,7 @@ ShallowWrapper {
                   >
                     <a
                       className="green-text"
-                      href="/profiles/view/undefined/"
+                      href="/profiles/view/undefined"
                     />
                   </span>,
                 ],
@@ -240,7 +240,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": <a
                       className="green-text"
-                      href="/profiles/view/undefined/"
+                      href="/profiles/view/undefined"
                     />,
                     "className": "card-title",
                   },
@@ -252,7 +252,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": undefined,
                       "className": "green-text",
-                      "href": "/profiles/view/undefined/",
+                      "href": "/profiles/view/undefined",
                     },
                     "ref": null,
                     "rendered": null,
@@ -365,7 +365,7 @@ ShallowWrapper {
                 >
                   <a
                     className="green-text"
-                    href="/profiles/view/undefined/"
+                    href="/profiles/view/undefined"
                   />
                 </span>
               </div>
@@ -410,7 +410,7 @@ ShallowWrapper {
                 >
                   <a
                     className="green-text"
-                    href="/profiles/view/undefined/"
+                    href="/profiles/view/undefined"
                   />
                 </span>
               </div>
@@ -452,7 +452,7 @@ ShallowWrapper {
                 >
                   <a
                     className="green-text"
-                    href="/profiles/view/undefined/"
+                    href="/profiles/view/undefined"
                   />
                 </span>
               </div>
@@ -491,7 +491,7 @@ ShallowWrapper {
                   >
                     <a
                       className="green-text"
-                      href="/profiles/view/undefined/"
+                      href="/profiles/view/undefined"
                     />
                   </span>
                 </div>,
@@ -528,7 +528,7 @@ ShallowWrapper {
                     >
                       <a
                         className="green-text"
-                        href="/profiles/view/undefined/"
+                        href="/profiles/view/undefined"
                       />
                     </span>,
                   ],
@@ -555,7 +555,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": <a
                         className="green-text"
-                        href="/profiles/view/undefined/"
+                        href="/profiles/view/undefined"
                       />,
                       "className": "card-title",
                     },
@@ -567,7 +567,7 @@ ShallowWrapper {
                       "props": Object {
                         "children": undefined,
                         "className": "green-text",
-                        "href": "/profiles/view/undefined/",
+                        "href": "/profiles/view/undefined",
                       },
                       "ref": null,
                       "rendered": null,

--- a/src/components/ProfileView/index.js
+++ b/src/components/ProfileView/index.js
@@ -11,7 +11,7 @@ const ProfileView = ({ profile }) => (
         <div className="card">
           <div className="card-image">
             <img src={profile.image || profileImage} alt="" />
-            <span className="card-title"><a className="green-text" href={profile && `/profiles/view/${profile.username}/`}>{ profile.username }</a></span>
+            <span className="card-title"><a className="green-text" href={profile && `/profiles/view/${profile.username}`}>{ profile.username }</a></span>
           </div>
           <div className="card-content">
             <div className="followButton">

--- a/src/containers/NavBar/index.js
+++ b/src/containers/NavBar/index.js
@@ -16,33 +16,37 @@ class NavBar extends React.Component {
     hiddenLoader: false,
   };
 
-  getProfileDropDown = () => (
-    <DropDown
-      id="profile-dropdown"
-      list={(
-        <>
-          <DropDownItem link={ROUTES.articles.createNew}>
-            New Article
-          </DropDownItem>
-          <DropDownItem link={ROUTES.profiles.view} classNames="divided top">
-            My Profile
-          </DropDownItem>
-          <DropDownItem link={ROUTES.me.articles}>
-            My Articles
-          </DropDownItem>
-          <DropDownItem link={ROUTES.me.stats}>
-            My Stats
-          </DropDownItem>
-          <DropDownItem link={ROUTES.settings}>
-            Settings
-          </DropDownItem>
-          <DropDownItem onClick={this.logout}>
-            Logout
-          </DropDownItem>
-        </>
-      )}
-    />
-  );
+  getProfileDropDown = () => {
+    let { user } = this.props;
+    user = !user ? getCurrentUser() : user;
+    return (
+      <DropDown
+        id="profile-dropdown"
+        list={(
+          <>
+            <DropDownItem link={ROUTES.articles.createNew}>
+              New Article
+            </DropDownItem>
+            <DropDownItem link={`/profiles/view/${user.username}`} classNames="divided top">
+              My Profile
+            </DropDownItem>
+            <DropDownItem link={ROUTES.me.articles}>
+              My Articles
+            </DropDownItem>
+            <DropDownItem link={ROUTES.me.stats}>
+              My Stats
+            </DropDownItem>
+            <DropDownItem link={ROUTES.settings}>
+              Settings
+            </DropDownItem>
+            <DropDownItem onClick={this.logout}>
+              Logout
+            </DropDownItem>
+          </>
+        )}
+      />
+    );
+  };
 
   logout = () => {
     localStorage.removeItem("user");

--- a/src/containers/profiles/EditProfiles/index.js
+++ b/src/containers/profiles/EditProfiles/index.js
@@ -17,10 +17,8 @@ class EditProfiles extends Component {
   };
 
   componentDidMount = () => {
-    const { history, user } = this.props;
     const modal = document.querySelector('#edit-profile-modal');
     Materialize.Modal.init(modal, {});
-    history.push(`/profiles/edit/${user.username}`);
   };
 
   onChange = (e) => {
@@ -98,7 +96,6 @@ export const mapStateToProps = state => ({
 EditProfiles.propTypes = {
   editUserProfile: PropTypes.func.isRequired,
   user: PropTypes.shape({}).isRequired,
-  history: PropTypes.shape().isRequired,
   profile: PropTypes.shape({
     image: PropTypes.shape([]).isRequired,
     bio: PropTypes.string.isRequired,

--- a/src/containers/profiles/ViewProfiles/index.js
+++ b/src/containers/profiles/ViewProfiles/index.js
@@ -14,22 +14,12 @@ import UsersListing from "../../UsersListing";
 import { getCurrentUser } from "../../../utils/auth";
 
 export class ViewProfiles extends Component {
-  modal = React.createRef();
-
   componentDidMount = () => {
-    const { history, user } = this.props;
-    const modals = document.querySelector(".modal");
     Materialize.Tabs.init(document.querySelector(".tabs"), {});
-    Materialize.Modal.init(modals, {});
     const { getUserProfile, match = {} } = this.props;
     const { params = {} } = match;
     const { username } = params;
-    if (username === ':username') {
-      getUserProfile(user.username);
-      history.push(`/profile/view/${user.username}`);
-    }
     getUserProfile(username);
-    history.push(`/profiles/view/${username}`);
   };
 
 

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -19,7 +19,6 @@ const ROUTES = {
   resetPassword: '/reset-password',
   profiles: {
     view: '/profiles/view/:username',
-    update: '/profiles/edit/:username',
   },
   settings: '/settings',
   search: '/search',


### PR DESCRIPTION
**What does this PR do?**

Fixes the following profile navigation inconsistencies:
 - Navigation to MyProfile - the address is incorrect
 - Navigation to and from followers and following
 - Navigation to article creator profile and back

**Description of Task to be completed?**

#### Problem 1
##### Steps to reproduce
1. Log in
2. Go to My Profile.

##### Expected
The address should look like this `https://ah-cd-frontend-staging.herokuapp.com/profiles/view/mutaimwiti40`. 

##### Actual
The address looks like this `https://ah-cd-frontend-staging.herokuapp.com/profiles/view/:username`. This is wrong since it should have the username of the current user.

#### Problem 2
##### Steps to reproduce
1. Click one of your follows.
2. Press back on the browser.

##### Expected
It should take you back to your profile.

##### Actual
It is unable to load the page with the address looking like `https://ah-cd-frontend-staging.herokuapp.com/profiles/edit/mutaimwiti40`

#### Problem 3
##### Steps to reproduce
1. Log in.
2. Open any article.
3. Click on the profile of the owner of the article.
4. Click back on the browser.

##### Expected
It should take you back to the article.

##### Actual
It is unable to load the page with the address looking something like `https://ah-cd-frontend-staging.herokuapp.com/profiles/edit/mutaimwiti40`.

**How should this be manually tested?**

Visit this PR's review apps and carefully confirm that all the three bug scenarios have been eliminated.

**What are the relevant pivotal tracker stories?**

[#162339528](https://www.pivotaltracker.com/story/show/162339528)