### PR TITLE
#162340315 Fix request handling by api interceptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "redux-thunk": "^2.3.0",
     "sinon": "^7.1.1",
     "sweetalert": "^2.1.2",
-    "truncate": "^2.0.1"
+    "truncate": "^2.0.1",
+    "url-pattern": "^1.0.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/containers/NetworkPopup/index.js
+++ b/src/containers/NetworkPopup/index.js
@@ -18,7 +18,7 @@ export class NetWorkPopup extends Component {
   getModal = () => this.ref.current;
 
   componentDidMount() {
-    Materialize.Modal.init(this.getModal(), { dismissible: false });
+    Materialize.Modal.init(this.getModal(), { dismissible: true });
   }
 
   componentDidUpdate() {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import UrlPattern from "url-pattern";
 import config from './config';
 import { getToken } from './auth';
 import store from '../store';
@@ -14,6 +15,10 @@ const api = axios.create({
   baseURL: uri,
 });
 
+/*
+Perform manipulation on request config before the request is made.
+- set token
+ */
 api.interceptors.request.use(
   (cfg) => {
     if (token) {
@@ -23,27 +28,46 @@ api.interceptors.request.use(
   },
 );
 
+/*
+An array defining routes that should never cause a network error.
+ */
+const NW_ERR_BLACKLISTED_ROUTES = [
+  'articles/:slug/reactions/',
+];
+
+/*
+Check whether an error response is network error blacklisted.
+ */
+const isNetworkErrorBlacklisted = (error) => {
+  let isBlacklisted = false;
+  NW_ERR_BLACKLISTED_ROUTES.forEach((route) => {
+    const pattern = new UrlPattern(route);
+    isBlacklisted = pattern.match(error.config.url.split(uri)[1]) ? true : isBlacklisted;
+  });
+  return isBlacklisted;
+};
+
+/*
+Intercept request responses and perform actions that need to be performed
+before returning to the promise.
+- handle network errors
+- handle auth errors
+ */
 api.interceptors.response.use(
   (response) => {
     store.dispatch({ type: NO_NETWORK_ERROR });
     return response;
   },
   (error) => {
-    if (!error.response) {
+    if (error.response && error.response.status === 401) {
+      localStorage.setItem('user', null);
+      window.location.assign(`${window.location.protocol}//${window.location.host.toString()}/login`);
+    }
+    if (!error.response && !isNetworkErrorBlacklisted(error)) {
       store.dispatch({ type: NETWORK_ERROR_DETECTED });
     }
     return Promise.reject(error);
   },
 );
 
-api.interceptors.response.use(
-  response => response,
-  (error) => {
-    if (error.response && error.response.status === 403) {
-      localStorage.setItem('user', null);
-      window.location.assign(`${window.location.protocol}//${window.location.host.toString()}/login`);
-    }
-    return Promise.reject(error);
-  },
-);
 export default api;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10730,6 +10730,11 @@ url-parse@^1.1.8, url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-pattern@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/url-pattern/-/url-pattern-1.0.3.tgz#0409292471b24f23c50d65a47931793d2b5acfc1"
+  integrity sha1-BAkpJHGyTyPFDWWkeTF5PStaz8E=
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
**What does this PR do?**

Fixes the following on the api module:
- Auth interceptor by handling only 401 errors.
- Network interceptor by adding a list of blacklisted routes.

**Description of Task to be completed?**

#### Issue 1
##### Steps to reproduce
1. Ensure you're logged out 
2. Try to open an article

##### Expected
Should open for viewing.

##### Actual
Starts opening but redirects to login. This is caused by the auth interceptor which tries to intercept 403 errors instead of 401.

#### Issue 2
##### Steps to reproduce
1. Ensure you're logged in 
2. Open an article.
3. Simulate offline mode on browser Devtools.
4. Wait for the article to try and refresh reactions.

##### Expected
It should not bring up the network error popup because reaction refresh error should not prevent users from reading the article.

##### Actual
It brings up the network error popup.

**How should this be manually tested?**

Open this PR's review app and carefully test the two scenarios.

**What are the relevant pivotal tracker stories?**

[#162340315](https://www.pivotaltracker.com/story/show/162340315)